### PR TITLE
Convert `labels<-` to S4 generic function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 * Dataset `faux_cell` and function `generate_faux_cell()` replace `chondro` dataset (cbeleites/hyperSpec#125, cbeleites/hyperSpec#156, cbeleites/hyperSpec#180, cbeleites/hyperSpec#229).
 * Documentation aliases have been updated. Now, ?hyperSpec points to the function `hyperSpec()`, and to refer to the package, `package?hyperSpec` should be used (#129).
 * Vignette `hyperSpec.Rmd`: suggested packages (`pls`) are now loaded conditionally so the vignette builds even when they are not installed.
+* Function `labels<-()` converted into an S4 generic, making it consistent with the existing `labels()` S4 generic (r-hyperspec/hyperSpec#115).
 
 
 ### Bugfixes

--- a/R/labels.R
+++ b/R/labels.R
@@ -140,7 +140,8 @@ hySpc.testthat::test(.labels) <- function() {
 #' @examples
 #'
 #' labels(flu, "c") <- expression("/"("c", "mg / l"))
-`labels<-` <- function(object, which = NULL, ..., value) {
+# helper function (similar to .labels for the getter)
+.labels_replace <- function(object, which = NULL, ..., value) {
   assert_hyperSpec(object)
   validObject(object)
 
@@ -162,6 +163,17 @@ hySpc.testthat::test(.labels) <- function() {
   validObject(object)
   object
 }
+
+# generic replacement function
+#' @export
+setGeneric("labels<-", function(object, which = NULL, ..., value) {
+  standardGeneric("labels<-")
+})
+
+setMethod("labels<-", 
+  signature = signature(object = "hyperSpec"), 
+  .labels_replace
+)
 
 
 # Unit tests -----------------------------------------------------------------


### PR DESCRIPTION
Issue:
-  #115 
- https://github.com/cbeleites/hyperSpec/issues/342

Converts `labels<-` into a generic S4 function.
The labels() getter was already a generic S4 function, but the setter was not, thus creating an inconsistency. Now both are S4 generics.

Before:
<img width="366" height="226" alt="image" src="https://github.com/user-attachments/assets/15b4de8e-1303-4380-937d-21aa939562b9" />

After:
<img width="373" height="115" alt="image" src="https://github.com/user-attachments/assets/706c0215-ea54-4adf-81c5-a90bdbcf0fc1" />
