### PR TITLE
feat: Creating a hyperSpec object without spectra

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 ### Bugfixes
 
 * Possibility to initialize `hyperSpec` object by providing wavelengths only (cbeleites/hyperSpec#288).
+* Possibility to initialize `hyperSpec` object providing only `data` without `spc` (cbeleites/hyperSpec#296).
 * Column names in spectra matrix (`$spc` column of `hyperSpec` object) are now returned correctly by functions `spc.bin()` (cbeleites/hyperSpec#237), and `spc.loess()` (cbeleites/hyperSpec#245
 * `all.equal()` method for `hyperSpec` objects converted from S4 to S3 registration. The S4 `setMethod()` approach for this S3 generic caused roxygen2 (>= 7.3) to crash during documentation generation.
 * `rbind.fill()` (internal): strip the `AsIs` class from matrix columns after data frame assembly. R >= 4.4 introduced `all.equal.AsIs()` which caused spurious class-mismatch failures when comparing `hyperSpec` objects that had been through `rbind` or `collapse`.

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -96,6 +96,9 @@
 #'   spc = spc
 #' )
 #'
+#' # data only, no spectra
+#' new("hyperSpec", data = data.frame(x = 1:5))
+#'
 #' colnames(spc) <- 600:603
 #' new("hyperSpec", spc = spc) # wavelength taken from colnames (spc)
 #'
@@ -203,7 +206,8 @@ NULL
 
   # Deal with spectra
   if (is.null(spc) && is.null(data$spc)) {
-    spc <- structure(numeric(0), .Dim = c(0L, 0L))
+    nrows <- if (!is.null(data)) nrow(data) else 0L
+    spc <- structure(numeric(0), .Dim = c(nrows, 0L))
   }
 
   if (!is.null(spc) && !is.matrix(spc)) {
@@ -397,6 +401,12 @@ hySpc.testthat::test(.initialize) <- function() {
     expect_equal(hy_obj_1c, hy_obj_2c)
   })
 
+  test_that("data only, no spc", {
+    h <- new("hyperSpec", data = data.frame(c = 1:5))
+    expect_equal(dim(h), c(nrow = 5L, ncol = 2L, nwl = 0L))
+    expect_equal(h@wavelength, numeric(0))
+    expect_equal(h$c, 1:5)
+  })
 
   test_that('hyperSpec() and new("hyperSpec") give identical results', {
     expect_equal(hyperSpec(), new("hyperSpec"))


### PR DESCRIPTION
Closes #99

**Line causing the problem** In `.initialize()`, when both `spc` and `data$spc` are NULL, the constructor creates a 0×0 empty matrix:
```r
spc <- structure(numeric(0), .Dim = c(0L, 0L))
```
This ignores nrow(data), causing a row-count mismatch that fails validation.

**Fix**: Just Accounted for nrow(data) when constructing the empty spectra matrix.

The PR is too simple to be true, am I missing something? Please correct me.  
**I did run all tests**:
<details>
<summary>
_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --no-vignettes hyperSpec_*.tar.gz
</summary>

```
* using log directory ‘/home/suryansh/dev/GSOC/hyperSpec/hyperSpec.Rcheck’
* using R version 4.5.3 (2026-03-11)
* using platform: x86_64-pc-linux-gnu
* R was compiled by
    gcc (GCC) 15.2.1 20260209
    GNU Fortran (GCC) 15.2.1 20260209
* running under: Arch Linux
* using session charset: UTF-8
* using options ‘--no-manual --no-vignettes’
* checking for file ‘hyperSpec/DESCRIPTION’ ... OK
* checking extension type ... Package
* this is package ‘hyperSpec’ version ‘0.200.0.9000’
* package encoding: UTF-8
* checking package namespace information ... OK
* checking package dependencies ... INFO
Packages suggested but not available for checking:
  'bookdown', 'caTools', 'colorspace', 'covr', 'kableExtra',
  'matrixStats', 'mvtnorm', 'plotrix', 'pls', 'reshape', 'reshape2',
  'rgl', 'sessioninfo', 'sp'
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for executable files ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking for sufficient/correct file permissions ... OK
* checking whether package ‘hyperSpec’ can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... OK
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking code files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* checking whether the package can be loaded ... OK
* checking whether the package can be loaded with stated dependencies ... OK
* checking whether the package can be unloaded cleanly ... OK
* checking whether the namespace can be loaded with stated dependencies ... OK
* checking whether the namespace can be unloaded cleanly ... OK
* checking loading without being on the library search path ... OK
* checking whether startup messages can be suppressed ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd cross-references ... INFO
Packages unavailable to check Rd xrefs: ‘caTools’, ‘reshape’, ‘reshape2’, ‘plyr’, ‘sp’, ‘plotrix’, ‘mvtnorm’
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking contents of ‘data’ directory ... OK
* checking data for non-ASCII characters ... OK
* checking LazyData ... OK
* checking data for ASCII and uncompressed saves ... OK
* checking R/sysdata.rda ... OK
* checking files in ‘vignettes’ ... WARNING
Files in the 'vignettes' directory but no files in 'inst/doc':
  ‘baseline.Rmd’ ‘elsevier-with-titles.csl’ ‘fileio--fileformats.txt’
  ‘fileio.bib’ ‘fileio.Rmd’ ‘flu.Rmd’ ‘hyperSpec.Rmd’
  ‘intro--structure--hyperSpec--objects.png’ ‘laser--rgl-3d.png’
  ‘laser.Rmd’ ‘list-of-vignettes.md’ ‘plotting--fig-3D-01.png’
  ‘plotting.Rmd’ ‘read.ENVI.Nicolet.R’ ‘read.txt.PerkinElmer.R’
  ‘style.css’
  ‘support/intro--structure--hyperSpec--objects--ORIGINAL.tex’
  ‘support/intro--structure--hyperSpec--objects.tex’
  ‘vignette-default-settings.R’ ‘vignette-functions.R’ ‘vignette.css’
* checking examples ... OK
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ...
  Running ‘testthat.R’
 ERROR
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
    'test-attached.R:3:1', 'test-attached.R:3:1', 'test-attached.R:3:1',
    'test-attached.R:3:1', 'test-attached.R:3:1', 'test-attached.R:3:1'

  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Failure ('test-attached.R:3:1'): base R based plot() gives expected output ──
  Expected `plot_mat()` to run silently.
  Actual noise: warnings.
  ── Failure ('test-attached.R:3:1'): non-increasing wavelength axis ─────────────
  Expected `plot_matrix(tmp)` to run silently.
  Actual noise: warnings.

  [ FAIL 2 | WARN 1 | SKIP 16 | PASS 1139 ]
  Error:
  ! Test failures.
  Execution halted
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes ... WARNING
Directory 'inst/doc' does not exist.
Package vignettes without corresponding single PDF/HTML:
  ‘baseline.Rmd’
  ‘fileio.Rmd’
  ‘flu.Rmd’
  ‘hyperSpec.Rmd’
  ‘laser.Rmd’
  ‘plotting.Rmd’
* checking running R code from vignettes ... SKIPPED
* checking re-building of vignette outputs ... SKIPPED
* DONE

Status: 1 ERROR, 2 WARNINGs
See
  ‘/home/suryansh/dev/GSOC/hyperSpec/hyperSpec.Rcheck/00check.log’
for details.
```

2 fails are due to missing suggested packages which has nothing to do with our `initialize.R` changes
</details>